### PR TITLE
Dependency maven:org.postgresql:postgresql:42.3.3 is vulnerable, safe…

### DIFF
--- a/flink-vvp-connector-adbpg/pom.xml
+++ b/flink-vvp-connector-adbpg/pom.xml
@@ -51,7 +51,7 @@ under the License.
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.3.3</version>
+			<version>42.3.8</version>
 			<scope>compile</scope>
 		</dependency>
 


### PR DESCRIPTION
… version 42.3.8

CVE-2022-31197 8.0 Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') vulnerability pending CVSS allocation CVE-2022-41946 5.5 Exposure of Sensitive Information to an Unauthorized Actor vulnerability with medium severity found