### PR TITLE
Fix "out of index" exception when sink table have multiple primary keys.

### DIFF
--- a/flink-vvp-connector-adbpg/src/test/java/org/apache/flink/connector/jdbc/table/AdbpgTableSinkITCase.java
+++ b/flink-vvp-connector-adbpg/src/test/java/org/apache/flink/connector/jdbc/table/AdbpgTableSinkITCase.java
@@ -45,7 +45,7 @@ public class AdbpgTableSinkITCase extends JdbcTableSinkITCaseBase {
         String adbpgPassword = AdbpgTestConfParser.INSTANCE.getPassword();
         paramList.add(
                 new Object[] {
-                    "adbpg", adbpgURL, adbpgUserName, adbpgPassword, "org.postgresql.Driver"
+                    "adbpg-nightly-1.13", adbpgURL, adbpgUserName, adbpgPassword, "org.postgresql.Driver"
                 });
 
         return paramList;


### PR DESCRIPTION
issue from [issue](https://github.com/aliyun/alibabacloud-analyticdb-postgresql-connector/issues/21)
When adbpg sink table have multiple primary keys, shouldn't get "out of index" exception when commit job.