### PR TITLE
report outofindex exception when sink table have multiple keys

### DIFF
--- a/flink-vvp-connector-adbpg/src/main/java/org/apache/flink/connector/jdbc/table/sink/AdbpgOutputFormat.java
+++ b/flink-vvp-connector-adbpg/src/main/java/org/apache/flink/connector/jdbc/table/sink/AdbpgOutputFormat.java
@@ -93,7 +93,7 @@ public class AdbpgOutputFormat extends RichOutputFormat<RowData> implements Clea
     private final JdbcRowConverter upsertConverter;
     private final StringFormatRowConverter copyModeRowConverter;
     private final AdbpgDialect adbpgDialect;
-    String[] fieldNamesStr;
+    String[] fieldNamesStrs;
     LogicalType[] lts;
     private String url;
     private String tableName;
@@ -160,7 +160,7 @@ public class AdbpgOutputFormat extends RichOutputFormat<RowData> implements Clea
 
     public AdbpgOutputFormat(
             int fieldNum,
-            String[] fieldNamesStr,
+            String[] fieldNamesStrs,
             String[] keyFields,
             LogicalType[] lts,
             ReadableConfig config
@@ -186,24 +186,23 @@ public class AdbpgOutputFormat extends RichOutputFormat<RowData> implements Clea
         this.lts = lts;
         this.rowDataSerializer = new RowDataSerializer(this.lts);
         Joiner joinerOnComma = Joiner.on(",").useForNull("null");
-        this.fieldNamesStr = fieldNamesStr;
-        this.fieldNames = joinerOnComma.join(fieldNamesStr);
+        this.fieldNamesStrs = fieldNamesStrs;
 
         if (keyFields != null) {
             this.pkTypes = new LogicalType[keyFields.length];
             for (int i = 0; i < keyFields.length; i++) {
                 pkFields.add(keyFields[i]);
                 int t = 0;
-                for (; t < fieldNamesStr.length; t++) {
-                    if (keyFields[i].equals(fieldNamesStr[t])) {
+                for (; t < fieldNamesStrs.length; t++) {
+                    if (keyFields[i].equals(fieldNamesStrs[t])) {
                         pkIndex.add(t);
                         break;
                     }
                 }
-                if (fieldNamesStr.length == t) {
+                if (fieldNamesStrs.length == t) {
                     throw new RuntimeException("Key cannot found in filenames.");
                 }
-                int keyIdx = fieldNames.indexOf(keyFields[i]);
+                int keyIdx = Arrays.asList(fieldNamesStrs).indexOf(keyFields[i]);
                 this.pkTypes[i] = lts[keyIdx];
             }
             this.primaryKeys = new HashSet<>(pkFields);
@@ -234,7 +233,7 @@ public class AdbpgOutputFormat extends RichOutputFormat<RowData> implements Clea
             int primaryIndex = 0;
             int excludedIndex = 0;
             for (int i = 0; i < fieldNum; i++) {
-                String fileName = fieldNamesStr[i];
+                String fileName = fieldNamesStrs[i];
                 fieldNamesStrCaseSensitive[i] = "\"" + fileName + "\"";
                 if (primaryKeys.contains(fileName)) {
                     primaryFieldNamesStr[primaryIndex] = fileName;
@@ -258,7 +257,7 @@ public class AdbpgOutputFormat extends RichOutputFormat<RowData> implements Clea
             int j = 0;
             this.updateStatementFieldIndices = new int[nonPrimaryFieldNamesStr.length + primaryFieldNamesStr.length];
             for (int i = 0; i < lts.length; ++i) {
-                if (Arrays.asList(this.primaryFieldNamesStr).contains(fieldNamesStr[i])) {
+                if (Arrays.asList(this.primaryFieldNamesStr).contains(fieldNamesStrs[i])) {
                     continue;
                 }
                 updateStatementFieldIndices[j] = i;
@@ -541,7 +540,7 @@ public class AdbpgOutputFormat extends RichOutputFormat<RowData> implements Clea
                     }
                 }
                 String sql =
-                        adbpgDialect.getDeleteStatementWithNull(tableName, fieldNamesStr, nullFieldsIndex);
+                        adbpgDialect.getDeleteStatementWithNull(tableName, fieldNamesStrs, nullFieldsIndex);
 
                 if (nullFieldsIndex.size() > 0) {
                     LogicalType[] types = new LogicalType[rowData.getArity() - nullFieldsIndex.size()];
@@ -608,10 +607,10 @@ public class AdbpgOutputFormat extends RichOutputFormat<RowData> implements Clea
                 long end = System.currentTimeMillis();
                 reportMetric(rows, start, end, bps);
             } else if (writeMode == 2) {            /** batch upsert */
-                String sql = adbpgDialect.getUpsertStatement(tableName, fieldNamesStr, primaryFieldNamesStr, nonPrimaryFieldNamesStr, support_upsert);
+                String sql = adbpgDialect.getUpsertStatement(tableName, fieldNamesStrs, primaryFieldNamesStr, nonPrimaryFieldNamesStr, support_upsert);
                 executeSqlWithPrepareStatement(sql, rows, rowConverter, false);
             } else if (writeMode == 0) {            /** batch insert */
-                String insertSql = adbpgDialect.getInsertIntoStatement(tableName, fieldNamesStr);
+                String insertSql = adbpgDialect.getInsertIntoStatement(tableName, fieldNamesStrs);
                 executeSqlWithPrepareStatement(insertSql, rows, rowConverter, false);
             } else {
                 LOG.error("Unsupported write mode: " + writeMode);
@@ -767,7 +766,7 @@ public class AdbpgOutputFormat extends RichOutputFormat<RowData> implements Clea
                     LOG.info("recreate copyManager within executeCopy");
                     copyManager = new CopyManager(baseConn);
                 }
-                String sql = adbpgDialect.getCopyStatement(tableName, fieldNamesStr, "STDIN", conflictMode, support_upsert);
+                String sql = adbpgDialect.getCopyStatement(tableName, fieldNamesStrs, "STDIN", conflictMode, support_upsert);
                 LOG.info("Writing data with sql:" + sql);
                 copyManager.copyIn(sql, inputStream);
                 break;
@@ -792,7 +791,7 @@ public class AdbpgOutputFormat extends RichOutputFormat<RowData> implements Clea
      * @param row
      */
     private void upsertRow(RowData row) {
-        String sql = adbpgDialect.getUpsertStatement(tableName, fieldNamesStr, primaryFieldNamesStr, nonPrimaryFieldNamesStr, support_upsert);
+        String sql = adbpgDialect.getUpsertStatement(tableName, fieldNamesStrs, primaryFieldNamesStr, nonPrimaryFieldNamesStr, support_upsert);
         LOG.debug("Upserting row with sql:" + sql);
         try {
             executeSqlWithPrepareStatement(sql, Collections.singletonList(row), rowConverter, false);

--- a/flink-vvp-connector-adbpg/src/main/java/org/apache/flink/connector/jdbc/table/utils/AdbpgOptions.java
+++ b/flink-vvp-connector-adbpg/src/main/java/org/apache/flink/connector/jdbc/table/utils/AdbpgOptions.java
@@ -95,7 +95,7 @@ public class AdbpgOptions {
     public static final ConfigOption<Integer> BATCH_WRITE_TIMEOUT_MS =
             ConfigOptions.key("batchwritetimeoutms")
                     .intType()
-                    .defaultValue(50000)
+                    .defaultValue(10000)
                     .withDescription("Timeout setting");
     public static final ConfigOption<Integer> CONNECTION_MAX_ACTIVE =
             ConfigOptions.key("connectionmaxactive")

--- a/flink-vvp-connector-adbpg/src/test/java/README.md
+++ b/flink-vvp-connector-adbpg/src/test/java/README.md
@@ -1,0 +1,13 @@
+# How to run unittests
+
+## Setup envs
+```bash
+export ADBPG_URL="jdbc:postgresql://${INSTANCE_ID}-master.gpdb.zhangbei.rds.aliyuncs.com:5432/postgres"
+export ADBPG_USERNAME="${YOUR_USERNAME}"
+export ADBPG_PASSWORD="${YOUR_PASSWORD}"
+```
+
+## Run mvn test
+```bash
+mvn test
+```

--- a/flink-vvp-connector-adbpg/src/test/java/org/apache/flink/connector/jdbc/table/AdbpgDynamicSinkTestForInsert.java
+++ b/flink-vvp-connector-adbpg/src/test/java/org/apache/flink/connector/jdbc/table/AdbpgDynamicSinkTestForInsert.java
@@ -32,9 +32,12 @@ import java.sql.ResultSet;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+
 import static org.apache.flink.connector.jdbc.table.utils.AdbpgOptions.CONNECTOR_TYPE;
 
-/** Tests the adbpg sink. */
+/**
+ * Tests the adbpg sink.
+ */
 @RunWith(Parameterized.class)
 public class AdbpgDynamicSinkTestForInsert extends LegacyJdbcSinkFunctionITCaseBase {
 
@@ -52,12 +55,8 @@ public class AdbpgDynamicSinkTestForInsert extends LegacyJdbcSinkFunctionITCaseB
                     {
                         this.put("connector", CONNECTOR_TYPE);
                         this.put(AdbpgOptions.URL.key(), AdbpgTestConfParser.INSTANCE.getURL());
-                        this.put(
-                                AdbpgOptions.USERNAME.key(),
-                                AdbpgTestConfParser.INSTANCE.getUsername());
-                        this.put(
-                                AdbpgOptions.PASSWORD.key(),
-                                AdbpgTestConfParser.INSTANCE.getPassword());
+                        this.put(AdbpgOptions.USERNAME.key(), AdbpgTestConfParser.INSTANCE.getUsername());
+                        this.put(AdbpgOptions.PASSWORD.key(), AdbpgTestConfParser.INSTANCE.getPassword());
                         this.put(AdbpgOptions.TABLE_NAME.key(), TEST_TABLE_NAME);
                         this.put(AdbpgOptions.BATCH_SIZE.key(), "20");
                         this.put(AdbpgOptions.WRITE_MODE.key(), "0");
@@ -68,12 +67,8 @@ public class AdbpgDynamicSinkTestForInsert extends LegacyJdbcSinkFunctionITCaseB
                     {
                         this.put("connector", CONNECTOR_TYPE);
                         this.put(AdbpgOptions.URL.key(), AdbpgTestConfParser.INSTANCE.getURL());
-                        this.put(
-                                AdbpgOptions.USERNAME.key(),
-                                AdbpgTestConfParser.INSTANCE.getUsername());
-                        this.put(
-                                AdbpgOptions.PASSWORD.key(),
-                                AdbpgTestConfParser.INSTANCE.getPassword());
+                        this.put(AdbpgOptions.USERNAME.key(), AdbpgTestConfParser.INSTANCE.getUsername());
+                        this.put(AdbpgOptions.PASSWORD.key(), AdbpgTestConfParser.INSTANCE.getPassword());
                         this.put(AdbpgOptions.TABLE_NAME.key(), TEST_TABLE_NAME);
                         this.put(AdbpgOptions.BATCH_SIZE.key(), "20");
                         this.put(AdbpgOptions.WRITE_MODE.key(), "0");
@@ -85,12 +80,8 @@ public class AdbpgDynamicSinkTestForInsert extends LegacyJdbcSinkFunctionITCaseB
                     {
                         this.put("connector", CONNECTOR_TYPE);
                         this.put(AdbpgOptions.URL.key(), AdbpgTestConfParser.INSTANCE.getURL());
-                        this.put(
-                                AdbpgOptions.USERNAME.key(),
-                                AdbpgTestConfParser.INSTANCE.getUsername());
-                        this.put(
-                                AdbpgOptions.PASSWORD.key(),
-                                AdbpgTestConfParser.INSTANCE.getPassword());
+                        this.put(AdbpgOptions.USERNAME.key(), AdbpgTestConfParser.INSTANCE.getUsername());
+                        this.put(AdbpgOptions.PASSWORD.key(), AdbpgTestConfParser.INSTANCE.getPassword());
                         this.put(AdbpgOptions.TABLE_NAME.key(), TEST_TABLE_NAME);
                         this.put(AdbpgOptions.WRITE_MODE.key(), "0");
                         this.put(AdbpgOptions.BATCH_SIZE.key(), "20");

--- a/flink-vvp-connector-adbpg/src/test/java/org/apache/flink/connector/jdbc/table/AdbpgTableSinkITCase.java
+++ b/flink-vvp-connector-adbpg/src/test/java/org/apache/flink/connector/jdbc/table/AdbpgTableSinkITCase.java
@@ -45,7 +45,7 @@ public class AdbpgTableSinkITCase extends JdbcTableSinkITCaseBase {
         String adbpgPassword = AdbpgTestConfParser.INSTANCE.getPassword();
         paramList.add(
                 new Object[] {
-                    "adbpg", adbpgURL, adbpgUserName, adbpgPassword, "org.postgresql.Driver"
+                    "adbpg-nightly-1.13", adbpgURL, adbpgUserName, adbpgPassword, "org.postgresql.Driver"
                 });
 
         return paramList;


### PR DESCRIPTION
Fix "out of index" exception when sink table have multiple primary keys.

[issue](https://github.com/aliyun/alibabacloud-analyticdb-postgresql-connector/issues/21) 
When adbpg sink table have multiple primary keys, shouldn't get "out of index" exception when commit job.